### PR TITLE
Сlient authorization (connect to #47)

### DIFF
--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+
+export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
+  authorizer: 'authorizer:token'
+});

--- a/client/app/authorizers/token.js
+++ b/client/app/authorizers/token.js
@@ -1,0 +1,3 @@
+import TokenAuthorizer from 'ember-simple-auth-token/authorizers/token';
+
+export default TokenAuthorizer.extend();

--- a/client/app/components/login-form.js
+++ b/client/app/components/login-form.js
@@ -1,4 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  actions: {
+    submit() {
+      this.attrs.submit(this.getProperties('identification', 'password'));
+    }
+  }
 });

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service('session'),
+
+  actions: {
+    invalidateSession() {
+      this.get('session').invalidate();
+    }
+  }
+});

--- a/client/app/controllers/login.js
+++ b/client/app/controllers/login.js
@@ -9,6 +9,7 @@ export default Ember.Controller.extend({
       this.get('session').authenticate(authenticator, credentials)
         .then((res) => {
           this.set('errorMessage', null);
+          this.transitionToRoute('orders');
         })
         .catch((reason) => {
           this.set('errorMessage', reason.message || reason);

--- a/client/app/controllers/login.js
+++ b/client/app/controllers/login.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service('session'),
+
+  actions: {
+    authenticate(credentials) {
+      let authenticator = 'authenticator:jwt';
+      this.get('session').authenticate(authenticator, credentials);
+    }
+  }
+});

--- a/client/app/controllers/login.js
+++ b/client/app/controllers/login.js
@@ -6,7 +6,13 @@ export default Ember.Controller.extend({
   actions: {
     authenticate(credentials) {
       let authenticator = 'authenticator:jwt';
-      this.get('session').authenticate(authenticator, credentials);
+      this.get('session').authenticate(authenticator, credentials)
+        .then((res) => {
+          this.set('errorMessage', null);
+        })
+        .catch((reason) => {
+          this.set('errorMessage', reason.message || reason);
+        })
     }
   }
 });

--- a/client/app/routes/application.js
+++ b/client/app/routes/application.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(ApplicationRouteMixin, {
   session: Ember.inject.service(),
 
   beforeModel() {

--- a/client/app/routes/application.js
+++ b/client/app/routes/application.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  session: Ember.inject.service(),
+
+  beforeModel() {
+    this.get('session').loadCurrentAccount();
+  }
+});

--- a/client/app/routes/new-order.js
+++ b/client/app/routes/new-order.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model() {
     return Ember.RSVP.hash({
       vendors: this.store.findAll('vendor')

--- a/client/app/routes/new-portion-order.js
+++ b/client/app/routes/new-portion-order.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model(params) {
     return this.store.findRecord('order', params.order_id);
   }

--- a/client/app/routes/orders.js
+++ b/client/app/routes/orders.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model() {
     return this.store.findAll('order');
   }

--- a/client/app/services/session.js
+++ b/client/app/services/session.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import ESASession from 'ember-simple-auth/services/session';
+
+export default ESASession.extend({
+  store: Ember.inject.service(),
+
+  loadCurrentAccount: Ember.observer('isAuthenticated', function() {
+    if (this.get('isAuthenticated')) {
+      const jwt = Ember.getOwner(this).lookup('authenticator:jwt');
+      const payload = jwt.getTokenData(this.get('session.authenticated.token'));
+
+      this.get('store').find('account', payload).then((account) => {
+        this.set('account', account)
+      });
+    } else {
+      this.set('account', null);
+    }
+  })
+});

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -1,7 +1,9 @@
 <div class="wrapper">
   <nav>
     {{#if session.isAuthenticated}}
-      <a {{action 'invalidateSession'}}>Logout</a>
+      <p>Hello, {{session.account.name}}!
+        <a {{action 'invalidateSession'}}>Logout</a>
+      </p>
     {{else}}
       {{#link-to 'login'}}Login{{/link-to}}
     {{/if}}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -1,4 +1,12 @@
 <div class="wrapper">
+  <nav>
+    {{#if session.isAuthenticated}}
+      <a {{action 'invalidateSession'}}>Logout</a>
+    {{else}}
+      {{#link-to 'login'}}Login{{/link-to}}
+    {{/if}}
+  </nav>
+
   <section>
     <div class="container">
       {{outlet}}

--- a/client/app/templates/components/login-form.hbs
+++ b/client/app/templates/components/login-form.hbs
@@ -4,7 +4,7 @@
   <div class="form__row">
     <label class="form__label">
       <span class="form__label-text">* Почта</span>
-      {{input value=email class="form__field"}}
+      {{input value=identification class="form__field"}}
       </label>
   </div>
 

--- a/client/app/templates/login.hbs
+++ b/client/app/templates/login.hbs
@@ -1,1 +1,1 @@
-{{login-form model=model.account}}
+{{login-form submit=(action 'authenticate')}}

--- a/client/app/templates/login.hbs
+++ b/client/app/templates/login.hbs
@@ -1,1 +1,4 @@
 {{login-form submit=(action 'authenticate')}}
+{{#if errorMessage}}
+  <p>{{errorMessage}}</p>
+{{/if}}

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -19,6 +19,13 @@ module.exports = function(environment) {
     }
   };
 
+  ENV['ember-simple-auth-token'] = {
+    serverTokenEndpoint: '/auth/token',
+    authorizationPrefix: 'JWT ',
+    identificationField: 'email',
+    passwordField: 'password'
+  }
+
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -19,6 +19,10 @@ module.exports = function(environment) {
     }
   };
 
+  ENV['ember-simple-auth'] = {
+    authorizer: 'authorizer:token',
+  }
+
   ENV['ember-simple-auth-token'] = {
     serverTokenEndpoint: '/auth/token',
     authorizationPrefix: 'JWT ',

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "ember-cli-selectize": "^0.5.2",
+    "ember-simple-auth": "^1.1.0-beta.4",
+    "ember-simple-auth-token": "^1.1.1",
     "selectize": "^0.12.1"
   }
 }

--- a/client/tests/unit/adapters/application-test.js
+++ b/client/tests/unit/adapters/application-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:application', 'Unit | Adapter | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/client/tests/unit/controllers/application-test.js
+++ b/client/tests/unit/controllers/application-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:application', 'Unit | Controller | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/client/tests/unit/controllers/login-test.js
+++ b/client/tests/unit/controllers/login-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:login', 'Unit | Controller | login', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/client/tests/unit/routes/application-test.js
+++ b/client/tests/unit/routes/application-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:application', 'Unit | Route | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -15,7 +15,8 @@ module.exports = function applyRoutes(app) {
   app.get('/me', passport.authenticate('jwt'), function(req, res) {
     res.send(req.user);
   });
-  app.get('/:type(orders|accounts|portions|vendors)', api);
-  app.get('/:type(orders|accounts|portions|vendors)/:id', api);
-  app.post('/:type(orders|accounts|portions|vendors)', api);
+  app.get('/:type(orders|accounts|portions|vendors)', passport.authenticate('jwt'), api);
+  app.get('/:type(orders|accounts|portions|vendors)/:id', passport.authenticate('jwt'), api);
+  app.post('/:type(orders|portions|vendors)', passport.authenticate('jwt'), api);
+  app.post('/:type(accounts)', api);
 };

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -12,9 +12,6 @@ const auth = require('../app/controllers/auth');
 module.exports = function applyRoutes(app) {
   app.get('/', main.index);
   app.post('/auth/token', auth.token);
-  app.get('/me', passport.authenticate('jwt'), function(req, res) {
-    res.send(req.user);
-  });
   app.get('/:type(orders|accounts|portions|vendors)', passport.authenticate('jwt'), api);
   app.get('/:type(orders|accounts|portions|vendors)/:id', passport.authenticate('jwt'), api);
   app.post('/:type(orders|portions|vendors)', passport.authenticate('jwt'), api);


### PR DESCRIPTION
В совокупности с #48 и #52 доваляет авторизацию на клиенте, а именно:

- [x] При вводе логина и пароля получет `jwt`(#48)
- [x] При возникновении какой-либо ошибки пишет её под формой
- [x] После входа переходит на страницу заказов и показывает ссылку на выход из аккаунта
- [x] При успешной авторизации загружаю профиль текущего пользователя, с возможностью его использования в шаблонах
- [x] Запрещаю доступ на определённые страницы для неавторизованных пользователей (при попытке зайти на `/orders` произойдёт перенаправление на страницу логина) #52
- [x] При выходе из аккаунта текущая сессия инвалидируется и происходит перезагрузка приложения с последующим редиректом на страницу входа. Все открытые вкладки синхронизируются между собой (спасибо `ember-simple-auth`, поэтому при выходе из приложения в одной вкладке, в остальных сессия также инвалидируется.)
- [x] Закрываю API для неавторизированных пользователей

---
Использую [ember-simple-auth](https://github.com/simplabs/ember-simple-auth)/[ember-simple-auth-token](https://github.com/jpadilla/ember-simple-auth-token). Единственной недостаток который я нашёл – на форме логина нужно использовать жестко заданные имена для инпутов (`identification`, `password`).