### PR TITLE
Portion form (connect to #62)

### DIFF
--- a/client/app/components/f-portion.js
+++ b/client/app/components/f-portion.js
@@ -1,13 +1,14 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  session: Ember.inject.service(),
+
   actions: {
     submit() {
-      this.attrs.submit({
-        text: this.get('text'),
-        cost: this.get('cost'),
-        paid: this.get('paid')
-      });
+      this.attrs.submit(
+        this.get('session.account'),
+        this.getProperties('text', 'cost')
+      );
     }
   }
 });

--- a/client/app/controllers/new-portion-order.js
+++ b/client/app/controllers/new-portion-order.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    addToOrder(order, account, attrs) {
+      const portion = this.store.createRecord('portion', attrs);
+      portion.set('order', order);
+      portion.set('owner', account);
+      portion.save().then(() => {
+        order.get('portions').pushObject(portion);
+        order.save();
+      });
+    }
+  }
+});

--- a/client/app/controllers/new-portion-order.js
+++ b/client/app/controllers/new-portion-order.js
@@ -10,6 +10,7 @@ export default Ember.Controller.extend({
         order.get('portions').pushObject(portion);
         order.save();
       });
+      this.transitionToRoute('orders');
     }
   }
 });

--- a/client/app/models/portion.js
+++ b/client/app/models/portion.js
@@ -4,6 +4,6 @@ export default DS.Model.extend({
   text: DS.attr('string'),
   cost: DS.attr('number'),
   paid: DS.attr('boolean'),
-  owner: DS.attr('string'),
+  owner: DS.belongsTo('account'),
   order: DS.belongsTo('order')
 });

--- a/client/app/serializers/order.js
+++ b/client/app/serializers/order.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  attrs: {
+    portions: { serialize: true }
+  }
+});

--- a/client/app/templates/components/f-portion.hbs
+++ b/client/app/templates/components/f-portion.hbs
@@ -3,37 +3,23 @@
   <h2 class="f-default__title">Добавить к заказу</h2>
 
   <div class="f-portion__row">
-    <span class="f-portion__place">pzz.by</span>
-    <span class="f-portion__time">16:00</span>
+    <span class="f-portion__place">{{order.vendor.title}}/{{order.location}}</span>
+    <span class="f-portion__time">{{order.time}}</span>
   </div>
 
   <div class="f-default__wrapper">
     <div class="f-default__row">
       <label class="f-default__label">
-        <span class="f-default__label-text"></span>
-        <input type="text" class="f-default__field" placeholder="Имя" required/>
+        {{textarea value=text class="f-default__textarea" rows="4" placeholder="Заказ"}}
       </label>
     </div>
 
     <div class="f-default__row">
       <label class="f-default__label">
-        <input type="tel" class="f-default__field" placeholder="Телефон" required/>
+        {{input value=cost class="f-default__field" placeholder="Сумма"}}
       </label>
     </div>
-
-    <div class="f-default__row">
-      <label class="f-default__label">
-        <textarea class="f-default__textarea" rows="4" placeholder="Заказ" required></textarea>
-      </label>
-    </div>
-
-    <div class="f-default__row">
-      <label class="f-default__label">
-        <input type="tel" class="f-default__field" placeholder="Сумма" required/>
-      </label>
-    </div>
-
   </div>
 
-  <button type="submit" class="button _submit">Добавить</button>
+  <button {{action "submit"}} class="button _submit">Добавить</button>
 </form>

--- a/client/app/templates/new-portion-order.hbs
+++ b/client/app/templates/new-portion-order.hbs
@@ -1,1 +1,1 @@
-{{f-portion model=model}}
+{{f-portion order=model submit=(action 'addToOrder' model)}}

--- a/client/tests/unit/controllers/new-portion-order-test.js
+++ b/client/tests/unit/controllers/new-portion-order-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:new-portion-order', 'Unit | Controller | new portion order', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/client/tests/unit/serializers/order-test.js
+++ b/client/tests/unit/serializers/order-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('order', 'Unit | Serializer | order', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:order']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/server/app/models/portion.js
+++ b/server/app/models/portion.js
@@ -7,7 +7,7 @@ const portionSchema = new Schema({
   text: { type: String, required: true },
   cost: { type: Number, required: true },
   paid: { type: Boolean, required: true, default: false },
-  owner: { type: String, required: true },
+  owner: { ref: 'Account', type: Schema.ObjectId },
   order: { ref: 'Order', type: Schema.ObjectId }
 });
 

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -14,6 +14,7 @@ module.exports = function applyRoutes(app) {
   app.post('/auth/token', auth.token);
   app.get('/:type(orders|accounts|portions|vendors)', passport.authenticate('jwt'), api);
   app.get('/:type(orders|accounts|portions|vendors)/:id', passport.authenticate('jwt'), api);
+  app.patch('/:type(orders)/:id', passport.authenticate('jwt'), api);
   app.post('/:type(orders|portions|vendors)', passport.authenticate('jwt'), api);
   app.post('/:type(accounts)', api);
 };


### PR DESCRIPTION
- [x] Привязал модель заявки к заказу
- [x] Через API теперь можно обновить заказ
- [x] При сабмите формы заявки создаётся новая заявки и привязывается к текущему заказу и аккаунту
- [x] Редирект к списку заказов после сохранения заявки

---
Для тех кому интересны детали реализации

- сразу создаю модель заявки

- т.к. для привязки заявки к заказу мне нужен `id` заявки, то я сохраняю её и только потом добавляю к заказу (`portion.save().then()`)

- теперь мне нужно сохранить заказ с информацией о заявке, т.к. связь один ко многим, то мне нужно отправить данные в таком формате

  ```json
  "relationships":{
    "portions":{
      "data":[
        {"type":"portions","id":"572078214860f38f530e63ae"}
      ]
    }
  }
  ```
- для этого нужно в сериализаторе заказа **явно указать** что заявки тоже нужно сериализовать (по умолчанию этого не происходит)

  ```
  attrs: {
    portions: { serialize: true }
  }
  ```