### PR TITLE
Group order portions by owner (connect to #132)

### DIFF
--- a/client/app/helpers/group-by.js
+++ b/client/app/helpers/group-by.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+export function groupBy(iter, byPath) {
+  // eslint-disable-next-line new-cap
+  const result = Ember.A();
+
+  iter.forEach((item) => {
+    const _id = Ember.get(item, byPath);
+    const hasGroup = !!result.findBy('_id', _id);
+
+    if (!hasGroup) {
+      result.pushObject(Ember.Object.create({
+        _id,
+        // eslint-disable-next-line new-cap
+        list: Ember.A(),
+        grouper: Ember.get(item, byPath.split('.', 1)[0])
+      }));
+    }
+
+    result.findBy('_id', _id).get('list').pushObject(item);
+  });
+
+  return result;
+}
+
+export default Ember.Helper.extend({
+  compute([byPath, iter]) {
+    return groupBy(iter, byPath);
+  }
+});

--- a/client/app/helpers/group-by.js
+++ b/client/app/helpers/group-by.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
 
 export function groupBy(iter, byPath) {
-  // eslint-disable-next-line new-cap
-  const result = Ember.A();
+  const result = new Ember.A();
 
   iter.forEach((item) => {
     const _id = Ember.get(item, byPath);
@@ -11,8 +10,7 @@ export function groupBy(iter, byPath) {
     if (!hasGroup) {
       result.pushObject(Ember.Object.create({
         _id,
-        // eslint-disable-next-line new-cap
-        list: Ember.A(),
+        list: new Ember.A(),
         grouper: Ember.get(item, byPath.split('.', 1)[0])
       }));
     }

--- a/client/app/routes/order.js
+++ b/client/app/routes/order.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model(params) {
-    return this.store.findRecord('order', params.order_id);
+    return Ember.RSVP.hash({
+      order: this.store.findRecord('order', params.order_id),
+      portions: this.store.query('portion', {
+        filter: { simple: { order: params.order_id } }
+      })
+    });
   }
 });

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -18,11 +18,11 @@
   </div>
 
   <ul class="b-order__content">
-    {{#each order.portions as |portion|}}
+    {{#each (group-by "owner.id" portions) as |group|}}
       <li class="b-order__item">
         <div class="b-order__wrapper">
           <div class="b-order__row">
-            <span class="b-order__person">{{portion.owner.displayName}}</span>
+            <span class="b-order__person">{{group.grouper.displayName}}</span>
             <label class="b-order__checkbox-label">
               <input type="checkbox" class="b-order__checkbox">
               <span class="b-order__checkbox-text"></span>
@@ -30,21 +30,22 @@
           </div>
 
           <div class="b-order__row">
-            <span class="b-order__phone">тел.: {{portion.owner.phone}}</span>
-            <span class="b-order__sum">сумма: {{portion.cost}}</span>
+            <span class="b-order__phone">тел.: {{group.grouper.phone}}</span>
           </div>
         </div>
 
         <ul class="b-order__summary">
-          <li class="b-order__info">
-            <div class="b-order__left">
-              <div class="b-order__image"></div>
-            </div>
-            <div class="b-order__right">
-              <div class="b-order__dish">{{portion.text}}</div>
-              <span class="b-order__amount">{{portion.cost}}</span>
-            </div>
-          </li>
+          {{#each group.list as |portion|}}
+            <li class="b-order__info">
+              <div class="b-order__left">
+                <div class="b-order__image"></div>
+              </div>
+              <div class="b-order__right">
+                <div class="b-order__dish">{{portion.text}}</div>
+                <span class="b-order__amount">{{portion.cost}}</span>
+              </div>
+            </li>
+          {{/each}}
         </ul>
       </li>
     {{/each}}

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -59,4 +59,4 @@
   </div>
 </div>
 
-{{#link-to "new-portion-order" order aria-label="add new portion" class="btn-new-order"}}{{/link-to}}
+{{#link-to "new-portion-order" order.id aria-label="add new portion" class="btn-new-order"}}{{/link-to}}

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -1,4 +1,4 @@
-{{#link-to 'order' order class="pr-order"}}
+{{#link-to 'order' order.id class="pr-order"}}
   <div class="pr-order__row">
     <div class="pr-order__place">{{order.vendor.title}}/{{order.location}}</div>
     <time class="pr-order__time">{{order.time}}</time>

--- a/client/app/templates/order.hbs
+++ b/client/app/templates/order.hbs
@@ -1,1 +1,1 @@
-{{b-order order=model}}
+{{b-order order=model.order portions=model.portions}}

--- a/client/tests/unit/helpers/group-by-test.js
+++ b/client/tests/unit/helpers/group-by-test.js
@@ -1,0 +1,10 @@
+import { groupBy } from 'client/helpers/group-by';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | group by');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = groupBy([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
Группирую заявки на странице заказа по их автору

- Добавил отдельный `helper` для группировки данных по указанному аттрибуту. 

- Загружаю необходимые данные до того как рендерю шаблон. Если этого не делать, то при перезагрузке страницы, до тех пор пока новые данные не загружены показываются пустые компоненты. Кроме этого я все заявки загружаю в один запрос, а не по одному запросу на каждую заявку.

- В `link-to` явно передаю не модель, а только те параметры что нужны для создания ссылки. Если передать модель, то Ember не вызывает `model hook` в соответствующем роуте, а просто использует указаную модель. Это хорошо до тех пор, пока модель не возвращает несколько объектов (как в нашем случае) через `Ember.RSVP.hash`. Нам нужно чтобы наши объекты были загружены в любом случае, поэтому модель из `link-to` я убрал.