### PR TITLE
Account settings (connect to #134)

### DIFF
--- a/client/app/components/f-account.js
+++ b/client/app/components/f-account.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actions: {
+    submit() {
+      return this.attrs.submit();
+    }
+  }
+});

--- a/client/app/controllers/account/index.js
+++ b/client/app/controllers/account/index.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service(),
+
+  actions: {
+    updateAccount(account) {
+      account.save();
+    }
+  }
+});

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -19,6 +19,8 @@ Router.map(function() {
   this.route('login');
   this.route('vendors', { path: '/vendors' });
   this.route('checkout', { path: '/orders/:order_id/checkout' });
+  // eslint-disable-next-line prefer-arrow-callback
+  this.route('account', function() {});
 });
 
 export default Router;

--- a/client/app/routes/account/index.js
+++ b/client/app/routes/account/index.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
+});

--- a/client/app/serializers/account.js
+++ b/client/app/serializers/account.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
-  serialize() {
-    const json = this._super.apply(this, arguments);
+  serialize(...args) {
+    const json = this._super.apply(this, args);
     const password = json.data.attributes.password;
     if (typeof password === 'undefined' || password === null) {
       delete json.data.attributes.password;

--- a/client/app/serializers/account.js
+++ b/client/app/serializers/account.js
@@ -1,7 +1,13 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
-  attrs: {
-    password: { serialize: false }
+  serialize() {
+    const json = this._super.apply(this, arguments);
+    const password = json.data.attributes.password;
+    if (typeof password === 'undefined' || password === null) {
+      delete json.data.attributes.password;
+    }
+
+    return json;
   }
 });

--- a/client/app/serializers/account.js
+++ b/client/app/serializers/account.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  attrs: {
+    password: { serialize: false }
+  }
+});

--- a/client/app/templates/account/index.hbs
+++ b/client/app/templates/account/index.hbs
@@ -1,0 +1,1 @@
+{{f-account account=session.account submit=(action 'updateAccount' session.account)}}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -18,6 +18,9 @@
             Orders
           {{/link-to}}
         </li>
+        <li class="m-site__item">
+          {{#link-to "account" class="m-site__link"}}Settings{{/link-to}}
+        </li>
         <li class="m-site__item _desktop-item">
           <button class="m-site__link" {{action 'invalidateSession'}}>
             <svg class="svg-logout" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 20">

--- a/client/app/templates/components/f-account.hbs
+++ b/client/app/templates/components/f-account.hbs
@@ -1,0 +1,26 @@
+<form class="f-default f-account">
+
+  <h2 class="f-default__title">Настройки аккаунта</h2>
+
+  <div class="f-default__wrapper">
+    <div class="f-default__row">
+      <label class="f-default__label">
+        {{input value=account.name class="f-default__field" placeholder="Name"}}
+      </label>
+    </div>
+
+    <div class="f-default__row">
+      <label class="f-default__label">
+        {{input value=account.email class="f-default__field" placeholder="Email"}}
+      </label>
+    </div>
+
+    <div class="f-default__row">
+      <label class="f-default__label">
+        {{input value=account.phone class="f-default__field" placeholder="Phone"}}
+      </label>
+    </div>
+  </div>
+
+  <button {{action "submit"}} class="button _submit">Сохранить настройки</button>
+</form>

--- a/client/tests/integration/components/f-account-test.js
+++ b/client/tests/integration/components/f-account-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('f-account', 'Integration | Component | f account', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{f-account}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#f-account}}
+      template block text
+    {{/f-account}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/client/tests/integration/components/f-account-test.js
+++ b/client/tests/integration/components/f-account-test.js
@@ -5,20 +5,27 @@ moduleForComponent('f-account', 'Integration | Component | f account', {
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+const accountStub = Ember.Object.create({
+  name: 'name',
+  email: 'email',
+  phone: 'phone'
+});
 
-  this.render(hbs`{{f-account}}`);
+test('it can be submitted', function(assert) {
+  this.on('submit', () => { assert.ok(true); })
 
-  assert.equal(this.$().text().trim(), '');
+  this.render(hbs`{{f-account submit=(action 'submit')}}`);
+  this.$('button').click()
+});
 
-  // Template block usage:
-  this.render(hbs`
-    {{#f-account}}
-      template block text
-    {{/f-account}}
-  `);
+test('it bound to account model', function(assert) {
+  this.set('account', accountStub);
+  this.on('submit', () => {});
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  this.render(hbs`{{f-account account=account submit=(action 'submit')}}`);
+  this.$('input').val('new name');
+  this.$('input').change();
+  this.$('button').click();
+
+  assert.ok(this.get('account.name') == 'new name');
 });

--- a/client/tests/unit/controllers/account/index-test.js
+++ b/client/tests/unit/controllers/account/index-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:account/index', 'Unit | Controller | account/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/client/tests/unit/routes/account/index-test.js
+++ b/client/tests/unit/routes/account/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:account/index', 'Unit | Route | account/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/client/tests/unit/serializers/account-test.js
+++ b/client/tests/unit/serializers/account-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('account', 'Unit | Serializer | account', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:account']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/client/tests/unit/serializers/account-test.js
+++ b/client/tests/unit/serializers/account-test.js
@@ -5,8 +5,22 @@ moduleForModel('account', 'Unit | Serializer | account', {
   needs: ['serializer:account']
 });
 
-test('should remove password attribute', function(assert) {
+test('should serialize password', function(assert) {
   let account = this.subject({ password: 'secret' });
+  let res = account.serialize();
+
+  assert.equal(res.data.attributes.password, 'secret');
+});
+
+test('should remove undefined password', function(assert) {
+  let account = this.subject({ password: undefined });
+  let res = account.serialize();
+
+  assert.notOk(res.data.attributes.hasOwnProperty('password'));
+});
+
+test('should remove null password', function(assert) {
+  let account = this.subject({ password: null });
   let res = account.serialize();
 
   assert.notOk(res.data.attributes.hasOwnProperty('password'));

--- a/client/tests/unit/serializers/account-test.js
+++ b/client/tests/unit/serializers/account-test.js
@@ -5,11 +5,9 @@ moduleForModel('account', 'Unit | Serializer | account', {
   needs: ['serializer:account']
 });
 
-// Replace this with your real tests.
-test('it serializes records', function(assert) {
-  let record = this.subject();
+test('should remove password attribute', function(assert) {
+  let account = this.subject({ password: 'secret' });
+  let res = account.serialize();
 
-  let serializedRecord = record.serialize();
-
-  assert.ok(serializedRecord);
+  assert.notOk(res.data.attributes.hasOwnProperty('password'));
 });

--- a/server/app/controllers/api/resource-descriptions/account.js
+++ b/server/app/controllers/api/resource-descriptions/account.js
@@ -5,8 +5,10 @@ module.exports = {
     self: '/accounts/{id}'
   },
 
-  beforeRender(resource) {
-    resource.removeAttr('email');
+  beforeRender(resource, req) {
+    if (req.params.id !== req.user.id) {
+      resource.removeAttr('email');
+    }
     resource.removeAttr('hashed_password');
     return resource;
   }

--- a/server/app/controllers/api/resource-descriptions/account.js
+++ b/server/app/controllers/api/resource-descriptions/account.js
@@ -6,7 +6,7 @@ module.exports = {
   },
 
   beforeRender(resource, req) {
-    if (req.params.id !== req.user.id) {
+    if (!req.user || req.params.id !== req.user.id) {
       resource.removeAttr('email');
     }
     resource.removeAttr('hashed_password');

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -17,4 +17,5 @@ module.exports = function applyRoutes(app) {
   app.patch('/:type(orders)/:id', passport.authenticate('jwt'), api);
   app.post('/:type(orders|portions|vendors)', passport.authenticate('jwt'), api);
   app.post('/:type(accounts)', api);
+  app.patch('/:type(accounts)/:id', passport.authenticate('jwt'), api);
 };


### PR DESCRIPTION
### Страница настроек аккаунта

- Добавил API для сохранения данных аккаунта на сервере

- Форма редактирования настроек (имя/почта/телефон) аккаунта. Для этого немного переделал API - теперь когда авторизованный пользователь запрашивает данные **о своем аккаунте**, его почта не скрывается.

- В меню добавил ссылку на настройки, правда без иконки. Её добавим потом.