### PR TITLE
Refactor application controller

### DIFF
--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -5,7 +5,7 @@ export default Ember.Controller.extend({
   open: false,
 
   openClass: Ember.computed('open', function() {
-    return this.get('open') ? 'open' : '';
+    return this.get('open') ? '_open' : '';
   }),
 
   authClass: Ember.computed('session.isAuthenticated', function() {

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  session: Ember.inject.service('session'),
   open: false,
 
   openClass: Ember.computed('open', function() {
     return this.get('open') ? 'open' : '';
   }),
-  session: Ember.inject.service('session'),
 
   isSign: Ember.computed('session.isAuthenticated', function() {
     return this.get('session.isAuthenticated') ? '' : 'wrapper__no-sign';

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -8,8 +8,8 @@ export default Ember.Controller.extend({
     return this.get('open') ? 'open' : '';
   }),
 
-  isSign: Ember.computed('session.isAuthenticated', function() {
-    return this.get('session.isAuthenticated') ? '' : 'wrapper__no-sign';
+  authClass: Ember.computed('session.isAuthenticated', function() {
+    return this.get('session.isAuthenticated') ? '' : 'wrapper__no-auth';
   }),
 
   actions: {

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -9,7 +9,7 @@ export default Ember.Controller.extend({
   }),
 
   authClass: Ember.computed('session.isAuthenticated', function() {
-    return this.get('session.isAuthenticated') ? '' : 'wrapper__no-auth';
+    return this.get('session.isAuthenticated') ? '' : '_no-auth';
   }),
 
   actions: {

--- a/client/app/styles/etc/helpers.styl
+++ b/client/app/styles/etc/helpers.styl
@@ -28,7 +28,7 @@
   height 100%
   min-height 100vh
 
-  &__no-sign
+  &__no-auth
     .i-logo
       left: 0
     .wrapper__content

--- a/client/app/styles/etc/helpers.styl
+++ b/client/app/styles/etc/helpers.styl
@@ -46,5 +46,5 @@
       margin-left 0
       background-image linear-gradient(to top, rgba($bg-dark, .35), rgba($bg-dark, .5)), url(img/bg-s.jpg)
 
-      .open &
+      ._open &
         transform translateX(80px);

--- a/client/app/styles/etc/helpers.styl
+++ b/client/app/styles/etc/helpers.styl
@@ -28,7 +28,7 @@
   height 100%
   min-height 100vh
 
-  &__no-auth
+  &._no-auth
     .i-logo
       left: 0
     .wrapper__content

--- a/client/app/styles/etc/i.styl
+++ b/client/app/styles/etc/i.styl
@@ -15,7 +15,7 @@
   z-index 4
 
   @media $max767
-    .open &
+    ._open &
       transform translateX(80px);
 
 

--- a/client/app/styles/sections/s-header.styl
+++ b/client/app/styles/sections/s-header.styl
@@ -11,7 +11,7 @@
   z-index 3
   transition transform 0.3s linear;
 
-  .open &
+  ._open &
     transform translateX(80px);
 
   &:before

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<div class="wrapper {{openClass}} {{isSign}}">
+<div class="wrapper {{openClass}} {{authClass}}">
   {{#if session.isAuthenticated}}
     <aside class="s-sidebar">
       <ul class="m-site" role="navigation" aria-label="main site menu" {{action 'hideMenu'}}>


### PR DESCRIPTION
- Перенёс определение `session` в верх контроллера к другим переменным

- По аналогии с `openClass` переименовал переменную содержащую класс для не авторизованных пользовалетей в `authClass`

- `wrapper__no-auth` это не элемент `wrapper`, а его модификатор, поэтому исправил название класса на `_no-auth`. Я думаю тоже самое нужно сделать и с `open`, но хотелось бы услышать мнение @Evvik, @IvanBisultanov 