### PR TITLE
Install and configure express logger in development environment (connect to #154)

### DIFF
--- a/server/config/logger.js
+++ b/server/config/logger.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const morgan = require('morgan');
+
+module.exports = function configureLogger(app) {
+  if (app.get('env') === 'development') {
+    app.use(morgan('dev'));
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,7 @@ module.exports = app;
 // Configure application
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+require('./config/logger')(app);
 require('./config/passport')(app, passport);
 
 // Bootstrap routes

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^5.7.0",
     "mongo": "^0.1.0",
     "mongoose": "^4.4.12",
+    "morgan": "^1.7.0",
     "passport": "^0.3.2",
     "passport-jwt": "^2.0.0"
   }


### PR DESCRIPTION
Логирую входящие запросы в `dev` окружении. Использую такой же формат логов, как и на клиенте

```
Express app started on http://127.0.0.1:3000
GET /orders 304 93.299 ms - -
GET /accounts/572a8c11cc98c9723b669468 304 82.020 ms - -
GET /vendors/571b71e64a2278aceb290bbd 304 14.392 ms - -
```