### PR TITLE
Refine UI

### DIFF
--- a/client/app/components/b-order-description.js
+++ b/client/app/components/b-order-description.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['b-order__description']
+});

--- a/client/app/styles/app.styl
+++ b/client/app/styles/app.styl
@@ -25,6 +25,7 @@
 @import 'blocks/tabs-list'
 @import 'blocks/portion-list'
 @import 'blocks/b-order'
+@import 'blocks/b-order-money'
 @import 'blocks/b-order-group'
 @import 'blocks/b-portion'
 

--- a/client/app/styles/app.styl
+++ b/client/app/styles/app.styl
@@ -28,6 +28,7 @@
 @import 'blocks/b-order-money'
 @import 'blocks/b-order-group'
 @import 'blocks/b-portion'
+@import 'blocks/b-person'
 
 // Forms
 @import "forms/f-default"

--- a/client/app/styles/blocks/b-order-group.styl
+++ b/client/app/styles/blocks/b-order-group.styl
@@ -13,16 +13,8 @@
       box-shadow 1px 1px 8px 0 rgba($bs-dark,.5)
 
   &__person
-  &__phone
     color $c-dark
-
-  &__person-name
     font-size $h3-font-size
-    line-height 1.6
-
-  &__person-phone
-    display block
-    font-size $h6-font-size
 
   &__summary
     padding: 15px

--- a/client/app/styles/blocks/b-order-group.styl
+++ b/client/app/styles/blocks/b-order-group.styl
@@ -14,18 +14,18 @@
 
   &__person
   &__phone
-  &__sum
     color $c-dark
 
-  &__person
-    font-size: 1.6rem
+  &__person-name
+    font-size $h3-font-size
+    line-height 1.6
 
-  &__phone
-  &__sum
-    font-size: 1.4rem
+  &__person-phone
+    display block
+    font-size $h6-font-size
 
   &__summary
-    padding: 20px
+    padding: 15px
     background: $bg-light;
     display: none
 

--- a/client/app/styles/blocks/b-order-money.styl
+++ b/client/app/styles/blocks/b-order-money.styl
@@ -1,0 +1,18 @@
+.b-order-money
+  text-align right
+
+  &__total
+  &__available
+    display inline
+
+  &__available
+    &:after
+      content ' /'
+
+  &__total
+    &._not-enough
+      color red
+
+  &__note
+    display block
+    font-size $h6-font-size

--- a/client/app/styles/blocks/b-order.styl
+++ b/client/app/styles/blocks/b-order.styl
@@ -1,6 +1,5 @@
 .b-order
   color $c-light
-  max-width 420px
   margin 0 auto
 
   &__description

--- a/client/app/styles/blocks/b-order.styl
+++ b/client/app/styles/blocks/b-order.styl
@@ -10,17 +10,17 @@
     margin-bottom 20px
 
   &__title
-    font-size 2.2rem
-    font-weight 700
+    font-size $h1-font-size
     text-align center
     margin-bottom 20px
 
-  &__info
-    display: flex
+  &__place
+  &__time
+    font-size $h2-font-size
 
-    &:not(:first-child)
-      margin-top: 10px
-      border-top: 1px solid rgba($bs-dark,.5)
+  &__manager
+  &__money
+    font-size: $h4-font-size
 
   &__row
     display flex

--- a/client/app/styles/blocks/b-person.styl
+++ b/client/app/styles/blocks/b-person.styl
@@ -1,0 +1,8 @@
+.b-person
+  &__name
+    line-height 1.6
+
+  &__phone
+    display block
+    font-size .7em
+

--- a/client/app/styles/blocks/b-portion.styl
+++ b/client/app/styles/blocks/b-portion.styl
@@ -9,6 +9,9 @@
     justify-content space-between
 
   &__text
-  &__cost
+    font-size $h4-font-size
     color $bg-dark
-    font-size 14px
+
+  &__cost
+    font-size $h5-font-size
+    color $bg-dark

--- a/client/app/styles/blocks/order-list.styl
+++ b/client/app/styles/blocks/order-list.styl
@@ -1,5 +1,4 @@
 .order-list
-  max-width 480px
   margin 0 auto
   overflow-y auto
   max-height calc(100vh - 200px)

--- a/client/app/styles/blocks/portion-list.styl
+++ b/client/app/styles/blocks/portion-list.styl
@@ -1,5 +1,4 @@
 .portion-list
-  max-width 480px
   margin 0 auto 20px
 
   &__item

--- a/client/app/styles/blocks/portion-list.styl
+++ b/client/app/styles/blocks/portion-list.styl
@@ -20,6 +20,6 @@
   &__cost
   &__paid
     font-weight 700
-    font-size 1.6rem
+    font-size $h4-font-size
     color $c-dark
 

--- a/client/app/styles/blocks/tabs-list.styl
+++ b/client/app/styles/blocks/tabs-list.styl
@@ -12,7 +12,7 @@
     line-height 4rem
     background grey
     font-weight 700
-    font-size 14px
+    font-size $h5-font-size
     text-transform uppercase;
     text-decoration none
     text-align center

--- a/client/app/styles/blocks/tabs-list.styl
+++ b/client/app/styles/blocks/tabs-list.styl
@@ -1,7 +1,6 @@
 .tabs-list
   display flex
   flex-wrap nowrap
-  max-width 480px
   margin 0 auto 20px
   box-shadow 1px 1px 5px 0 rgba($bs-dark,.5)
 

--- a/client/app/styles/etc/buttons.styl
+++ b/client/app/styles/etc/buttons.styl
@@ -5,7 +5,7 @@
   max-width 480px
   margin 0 auto
   display block
-  font-size 1.6rem
+  font-size $h4-font-size
   font-weight 700
   min-width 240px
   padding 0 15px

--- a/client/app/styles/etc/buttons.styl
+++ b/client/app/styles/etc/buttons.styl
@@ -2,7 +2,6 @@
   line-height 4rem
   text-align center
   width 100%
-  max-width 480px
   margin 0 auto
   display block
   font-size $h4-font-size

--- a/client/app/styles/etc/checkbox.styl
+++ b/client/app/styles/etc/checkbox.styl
@@ -5,11 +5,8 @@
     z-index -1
     opacity 0
 
-  &__label
-    font-weight 400
-
   &__text
-    font-size 1.4rem
+    font-size $h5-font-size
     position relative
     display inline-block
     width 14px

--- a/client/app/styles/etc/selectize.styl
+++ b/client/app/styles/etc/selectize.styl
@@ -14,7 +14,7 @@
         display block !important
         padding 0 10px !important
         height 3.6rem
-        font-size 1.4rem
+        font-size $h5-font-size
         line-height 3.6rem
         margin 0 !important
         &::placeholder

--- a/client/app/styles/forms/f-checkout.styl
+++ b/client/app/styles/forms/f-checkout.styl
@@ -1,5 +1,4 @@
 .f-checkout
-  max-width 420px
   margin 0 auto
 
   &__order-info

--- a/client/app/styles/forms/f-default.styl
+++ b/client/app/styles/forms/f-default.styl
@@ -1,6 +1,5 @@
 .f-default
   color $c-light
-  max-width 420px
   margin 0 auto 20px
 
   &__wrapper

--- a/client/app/styles/forms/f-default.styl
+++ b/client/app/styles/forms/f-default.styl
@@ -22,15 +22,14 @@
         border-top 1px solid rgba($bg-dark,.33)
 
   &__title
-    font-size 2.2rem
-    font-weight 700
+    font-size $h1-font-size
     text-align center
     margin-bottom 20px
 
   &__label
     font-weight 700
     color $c-dark
-    font-size 1.4rem
+    font-size $h5-font-size
     margin-bottom 4px
     display block
 
@@ -46,7 +45,7 @@
     border none
     padding 0 10px
     height 3.6rem
-    font-size 1.4rem
+    font-size $h5-font-size
     color $c-dark
     background transparent
 
@@ -54,7 +53,7 @@
       outline none
 
     &::placeholder
-      font-size 1.4rem
+      font-size $h5-font-size
       color rgba($c-dark,.33)
 
   &__textarea
@@ -63,12 +62,12 @@
     border none
     padding 5px 10px
     resize none
-    font-size 1.4rem
+    font-size $h5-font-size
 
     &:focus
       outline none
 
     &::placeholder
-      font-size 1.4rem
+      font-size $h5-font-size
       color rgba($c-dark,.33)
 

--- a/client/app/styles/forms/f-order.styl
+++ b/client/app/styles/forms/f-order.styl
@@ -7,6 +7,11 @@
   &__vendor-link
   &__vendor-min-cost
     color $c-dark
-    font-size 1.4rem
     line-height 3.6rem
     padding 0 10px
+
+  &__vendor-link
+    font-size $h5-font-size
+
+  &__vendor-min-cost
+    font-size $h6-font-size

--- a/client/app/styles/forms/f-portion.styl
+++ b/client/app/styles/forms/f-portion.styl
@@ -1,10 +1,1 @@
-.f-portion
-  &__row
-    display: flex
-    align-items: center
-    justify-content: space-between;
-    margin-bottom: 20px
-  &__time
-  &__place
-    font-size 1.6rem
-    font-weight 700
+// .f-portion

--- a/client/app/styles/menus/m-site.styl
+++ b/client/app/styles/menus/m-site.styl
@@ -1,6 +1,6 @@
 .m-site
   &__link
-    font-size 1.2rem
+    font-size $h6-font-size
     text-align center
     text-decoration none
     display block
@@ -35,7 +35,7 @@
         display block
 
     &__link
-      font-size 1.4rem
+      font-size $h5-font-size
       display flex
       justify-content flex-start;
       padding-left 18px;

--- a/client/app/styles/previews/pr-order.styl
+++ b/client/app/styles/previews/pr-order.styl
@@ -1,18 +1,19 @@
 .pr-order
   text-decoration none
+  display block
+  padding 10px
+  line-height 1.6
 
   &__row
     display flex
-    padding 10px
     justify-content space-between
 
   &__time
   &__place
-    font-weight 700
-    font-size 1.6rem
+    font-size $h2-font-size
     color $c-dark
 
   &__manager
-    font-weight 400
-    font-size 1.4rem
+  &__money
+    font-size $h4-font-size
     color $c-dark

--- a/client/app/styles/previews/pr-vendor-option.styl
+++ b/client/app/styles/previews/pr-vendor-option.styl
@@ -1,9 +1,10 @@
 .pr-vendor-option
 
   &__title
-    font-size 1.6rem
+    font-size $h4-font-size
     font-weight 700
 
   &__min-cost
-    font-size 1.2rem
+    font-size $h6-font-size
+    font-weight 400
     color $gr3

--- a/client/app/styles/sections/s-content.styl
+++ b/client/app/styles/sections/s-content.styl
@@ -12,3 +12,6 @@
 
   .container
     width 100%
+
+    @media $min480
+      max-width 480px

--- a/client/app/styles/sections/s-header.styl
+++ b/client/app/styles/sections/s-header.styl
@@ -31,7 +31,7 @@
     left 0
     right 0
     text-align center
-    font-size 1.4rem
+    font-size $h5-font-size
     color $c-dark
 
 

--- a/client/app/styles/settings/variables.styl
+++ b/client/app/styles/settings/variables.styl
@@ -16,6 +16,7 @@ $gr3 = #333
 $grD = #dadada
 
 // medias
+$min480 = 'only screen and (min-width 480px)'
 $max767 = 'only screen and (max-width 767px)'
 $min768 = 'only screen and (min-width 768px)'
 

--- a/client/app/styles/settings/variables.styl
+++ b/client/app/styles/settings/variables.styl
@@ -24,3 +24,12 @@ $min768 = 'only screen and (min-width 768px)'
 
 $bg-action = $orange
 $bg-primary = $orange
+
+
+// font sizes
+$h1-font-size = 2.3rem
+$h2-font-size = 2.0rem
+$h3-font-size = 1.8rem
+$h4-font-size = 1.6rem
+$h5-font-size = 1.4rem
+$h6-font-size = 1.2rem

--- a/client/app/templates/components/b-order-description.hbs
+++ b/client/app/templates/components/b-order-description.hbs
@@ -1,0 +1,26 @@
+<div class="b-order__row">
+  <div class="b-order__place">{{order.vendor.title}}</div>
+  <time class="b-order__time">{{order.time}}</time>
+</div>
+
+<div class="b-order__row">
+  <div class="b-order__manager b-person">
+    <div class="b-person__name">
+      {{order.manager.displayName}}/{{order.location}}
+    </div>
+  </div>
+  <div class="b-order__money b-order-money">
+    <span class="b-order-money__available">{{order.money.available}}</span>
+    {{#if order.isReady}}
+      <span class="b-order-money__total">{{order.money.total}}</span>
+    {{else}}
+      <span class="b-order-money__total _not-enough"
+            title="Минимальная сумма заказа {{order.money.required}}">
+        {{order.money.total}}
+      </span>
+      <div class="b-order-money__note">
+        Минимальная сумма заказа {{order.money.required}}
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/client/app/templates/components/b-order-group.hbs
+++ b/client/app/templates/components/b-order-group.hbs
@@ -1,8 +1,8 @@
 <div class="b-order-group__wrapper">
   <div class="b-order-group__row">
-    <div class="b-order-group__person">
-      <span class="b-order-group__person-name">{{owner.displayName}}</span>
-      <span class="b-order-group__person-phone">{{owner.phone}}</span>
+    <div class="b-order-group__person b-person">
+      <span class="b-person__name">{{owner.displayName}}</span>
+      <span class="b-person__phone">{{owner.phone}}</span>
     </div>
     {{b-checkbox class="b-order-group__checkbox" checked=allPaid onchange=(action 'toggleAll') }}
   </div>

--- a/client/app/templates/components/b-order-group.hbs
+++ b/client/app/templates/components/b-order-group.hbs
@@ -1,11 +1,10 @@
 <div class="b-order-group__wrapper">
   <div class="b-order-group__row">
-    <span class="b-order-group__person">{{owner.displayName}}</span>
+    <div class="b-order-group__person">
+      <span class="b-order-group__person-name">{{owner.displayName}}</span>
+      <span class="b-order-group__person-phone">{{owner.phone}}</span>
+    </div>
     {{b-checkbox class="b-order-group__checkbox" checked=allPaid onchange=(action 'toggleAll') }}
-  </div>
-
-  <div class="b-order-group__row">
-    <span class="b-order-group__phone">тел.: {{owner.phone}}</span>
   </div>
 </div>
 

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -1,34 +1,7 @@
 <div class="b-order">
   <h1 class="b-order__title">Информация о заказе</h1>
 
-  <div class="b-order__description">
-    <div class="b-order__row">
-      <div class="b-order__place">{{order.vendor.title}}</div>
-      <time class="b-order__time">{{order.time}}</time>
-    </div>
-
-    <div class="b-order__row">
-      <div class="b-order__manager b-person">
-        <div class="b-person__name">
-          {{order.manager.displayName}}/{{order.location}}
-        </div>
-      </div>
-      <div class="b-order__money b-order-money">
-        <span class="b-order-money__available">{{order.money.available}}</span>
-        {{#if order.isReady}}
-          <span class="b-order-money__total">{{order.money.total}}</span>
-        {{else}}
-          <span class="b-order-money__total _not-enough"
-                title="Минимальная сумма заказа {{order.money.required}}">
-            {{order.money.total}}
-          </span>
-          <div class="b-order-money__note">
-            Минимальная сумма заказа {{order.money.required}}
-          </div>
-        {{/if}}
-      </div>
-    </div>
-  </div>
+  {{b-order-description order=order}}
 
   <ul class="b-order__content">
     {{#each (group-by "owner.id" portions) as |group|}}

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -6,6 +6,7 @@
       <div class="b-order__place">{{order.vendor.title}}/{{order.location}}</div>
       <time class="b-order__time">{{order.time}}</time>
     </div>
+
     <div class="b-order__row">
       <div class="b-order__manager">{{order.manager.displayName}}</div>
       <div class="b-order__money">

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -9,11 +9,19 @@
 
     <div class="b-order__row">
       <div class="b-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
-      <div class="b-order__money">
-        {{order.money.available}}/{{order.money.total}}
-        {{#unless order.isReady}}
-          <span class="b-order__not-ready" title="Минимальная сумма заказа {{order.money.required}}">*</span>
-        {{/unless}}
+      <div class="b-order__money b-order-money">
+        <span class="b-order-money__available">{{order.money.available}}</span>
+        {{#if order.isReady}}
+          <span class="b-order-money__total">{{order.money.total}}</span>
+        {{else}}
+          <span class="b-order-money__total _not-enough"
+                title="Минимальная сумма заказа {{order.money.required}}">
+            {{order.money.total}}
+          </span>
+          <div class="b-order-money__note">
+            Минимальная сумма заказа {{order.money.required}}
+          </div>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -8,7 +8,11 @@
     </div>
 
     <div class="b-order__row">
-      <div class="b-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
+      <div class="b-order__manager b-person">
+        <div class="b-person__name">
+          {{order.manager.displayName}}/{{order.location}}
+        </div>
+      </div>
       <div class="b-order__money b-order-money">
         <span class="b-order-money__available">{{order.money.available}}</span>
         {{#if order.isReady}}

--- a/client/app/templates/components/b-order.hbs
+++ b/client/app/templates/components/b-order.hbs
@@ -3,12 +3,12 @@
 
   <div class="b-order__description">
     <div class="b-order__row">
-      <div class="b-order__place">{{order.vendor.title}}/{{order.location}}</div>
+      <div class="b-order__place">{{order.vendor.title}}</div>
       <time class="b-order__time">{{order.time}}</time>
     </div>
 
     <div class="b-order__row">
-      <div class="b-order__manager">{{order.manager.displayName}}</div>
+      <div class="b-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
       <div class="b-order__money">
         {{order.money.available}}/{{order.money.total}}
         {{#unless order.isReady}}

--- a/client/app/templates/components/f-portion.hbs
+++ b/client/app/templates/components/f-portion.hbs
@@ -2,9 +2,8 @@
 
   <h2 class="f-default__title">Добавить к заказу</h2>
 
-  <div class="f-portion__row">
-    <span class="f-portion__place">{{order.vendor.title}}/{{order.location}}</span>
-    <span class="f-portion__time">{{order.time}}</span>
+  <div class="f-portion__row b-order">
+    {{b-order-description order=order}}
   </div>
 
   <div class="f-default__wrapper">

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -4,7 +4,11 @@
     <time class="pr-order__time">{{order.time}}</time>
   </div>
   <div class="pr-order__row">
-    <div class="pr-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
+    <div class="pr-order__manager b-person">
+      <div class="b-person__name">
+        {{order.manager.displayName}}/{{order.location}}
+      </div>
+    </div>
     <div class="pr-order__money b-order-money">
       <span class="b-order-money__available">{{order.money.available}}</span>
       {{#if order.isReady}}

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -5,11 +5,16 @@
   </div>
   <div class="pr-order__row">
     <div class="pr-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
-    <div class="pr-order__money">
-      {{order.money.available}}/{{order.money.total}}
-      {{#unless order.isReady}}
-      <span class="pr-order__not-ready" title="Минимальная сумма заказа {{order.money.required}}">*</span>
-      {{/unless}}
+    <div class="pr-order__money b-order-money">
+      <span class="b-order-money__available">{{order.money.available}}</span>
+      {{#if order.isReady}}
+        <span class="b-order-money__total">{{order.money.total}}</span>
+      {{else}}
+        <span class="b-order-money__total _not-enough"
+              title="Минимальная сумма заказа {{order.money.required}}">
+          {{order.money.total}}
+        </span>
+      {{/if}}
     </div>
   </div>
 {{/link-to}}

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -1,6 +1,6 @@
 {{#link-to 'order' order.id class="pr-order"}}
   <div class="pr-order__row">
-    <div class="pr-order__place">{{order.vendor.title}}/{{order.location}}</div>
+    <div class="pr-order__place">{{order.vendor.title}}</div>
     <time class="pr-order__time">{{order.time}}</time>
   </div>
   <div class="pr-order__row">

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -4,7 +4,7 @@
     <time class="pr-order__time">{{order.time}}</time>
   </div>
   <div class="pr-order__row">
-    <div class="pr-order__manager">{{order.manager.displayName}}</div>
+    <div class="pr-order__manager">{{order.manager.displayName}}/{{order.location}}</div>
     <div class="pr-order__money">
       {{order.money.available}}/{{order.money.total}}
       {{#unless order.isReady}}

--- a/client/tests/integration/components/b-order-description-test.js
+++ b/client/tests/integration/components/b-order-description-test.js
@@ -1,0 +1,26 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('b-order-description', 'Integration | Component | b order description', {
+  integration: true
+});
+
+const orderStub = Ember.Object.create({
+  location: 'location',
+  time: 'time',
+  vendor: { title: 'vendor title' },
+  manager: { displayName: 'displayName' },
+  money: { available: 0, total: 42 },
+  isReady: true
+});
+
+test('should render order', function(assert) {
+  this.set('order', orderStub);
+  this.render(hbs`{{b-order-description order=order}}`);
+
+  assert.equal(this.$('.b-order__place').text(), 'vendor title');
+  assert.equal(this.$('.b-order__time').text(), 'time');
+  assert.equal(this.$('.b-person__name').text().trim(), 'displayName/location');
+  assert.equal(this.$('.b-order-money__available').text(), '0');
+  assert.equal(this.$('.b-order-money__total').text(), '42');
+});

--- a/client/tests/integration/components/b-order-group-test.js
+++ b/client/tests/integration/components/b-order-group-test.js
@@ -16,8 +16,8 @@ test('should render group', function(assert) {
   this.set('owner', ownerStub);
   this.render(hbs`{{b-order-group portions=portions owner=owner}}`);
 
-  assert.equal(this.$('.b-order-group__person').text(), 'me');
-  assert.equal(this.$('.b-order-group__phone').text(), 'тел.: hidden');
+  assert.equal(this.$('.b-person__name').text(), 'me');
+  assert.equal(this.$('.b-person__phone').text(), 'hidden');
   assert.equal(this.$('.b-portion').length, 2);
 });
 


### PR DESCRIPTION
- Почистил неиспользуемые стили

- Повторяющиеся элементы вынес в отдельные компоненты (`b-person`, `b-order-money`)

- Поубирал многократное повторение `max-width` у компонентов (оно было практически у каждого блока), и задал ограничение для самого контейнера.

- Вынес в переменные размеры используемых шрифтов и привёл их к единому виду (где-то был жирный, где-то был большой и т.п.). Теперь они не прыгают от страницы к странице, и одинаковые по смыслу элементы имеют одинаковый размер.

- Пока заказ не набрал необходимую сумму для оформления, то использую красный цвет для суммы заказа. Кроме этого показываю какая минимальная сумма заказа (#127)
<img width="518" alt="screen shot 2016-05-12 at 12 53 03 pm" src="https://cloud.githubusercontent.com/assets/1663958/15210990/99edb73e-1841-11e6-9e24-b5712a11e779.png">
