### PR TITLE
Fix portion/checkout form layouts

### DIFF
--- a/client/app/styles/forms/f-checkout.styl
+++ b/client/app/styles/forms/f-checkout.styl
@@ -5,7 +5,3 @@
     @media $max767
       font-size $h2-font-size
       margin-bottom 10px
-
-  &__order-info
-    border 1px solid $gr3
-    margin-bottom 25px

--- a/client/app/styles/forms/f-checkout.styl
+++ b/client/app/styles/forms/f-checkout.styl
@@ -1,6 +1,11 @@
 .f-checkout
   margin 0 auto
 
+  &__title
+    @media $max767
+      font-size $h2-font-size
+      margin-bottom 10px
+
   &__order-info
     border 1px solid $gr3
     margin-bottom 25px

--- a/client/app/styles/forms/f-portion.styl
+++ b/client/app/styles/forms/f-portion.styl
@@ -1,1 +1,6 @@
-// .f-portion
+.f-portion
+
+  &__title
+    @media $max767
+      font-size $h2-font-size
+      margin-bottom 10px

--- a/client/app/templates/components/f-checkout.hbs
+++ b/client/app/templates/components/f-checkout.hbs
@@ -1,13 +1,14 @@
 <form class="f-default f-checkout">
 
-  <h2 class="f-default__title">Отправить уведомление</h2>
+  <h2 class="f-default__title f-checkout__title">Отправить уведомление</h2>
 
-  {{b-order-description order=order}}
-
-  <div class="f-default__row">
-
-    {{b-textarea model=this valuePath='message' rows='4' placeholder='Введите сообщение'}}
-    <button {{action 'submit'}} type="submit" class="button _submit">Отправить уведомление</button>
+  <div class="b-order">
+    {{b-order-description order=order}}
   </div>
 
+  <div class="f-default__wrapper">
+    {{b-textarea model=this valuePath='message' rows='4' placeholder='Введите сообщение'}}
+  </div>
+
+  <button {{action 'submit'}} type="submit" class="button _submit">Отправить уведомление</button>
 </form>

--- a/client/app/templates/components/f-portion.hbs
+++ b/client/app/templates/components/f-portion.hbs
@@ -1,8 +1,8 @@
 <form class="f-default f-portion">
 
-  <h2 class="f-default__title">Добавить к заказу</h2>
+  <h2 class="f-default__title f-portion__title">Добавить к заказу</h2>
 
-  <div class="f-portion__row b-order">
+  <div class="b-order">
     {{b-order-description order=order}}
   </div>
 


### PR DESCRIPTION
- Оборачиваю `b-order-description` в `b-order` (closes #228)

- Делаю одинаковые размеры заголовков страниц на форме уведомлений/добавления заявки и странице заказа

- Оборачиваю `b-textarea` в `f-default__wrapper`, теперь сообщения об ошибках хорошо видны